### PR TITLE
ignore the editor-paste event if the type of the clipboard data is just text/plain; resolves #8

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Obsidian Excel to Markdown Table
 
-[![Tag 0.2.1](https://img.shields.io/badge/tag-0.2.1-blue)](https://github.com/ganesshkumar/obsidian-excel-to-markdown-table/releases/tag/0.2.1) 
+[![Tag 0.2.2](https://img.shields.io/badge/tag-0.2.2-blue)](https://github.com/ganesshkumar/obsidian-excel-to-markdown-table/releases/tag/0.2.2) 
 [![MIT License](https://img.shields.io/github/license/ganesshkumar/obsidian-excel-to-markdown-table)](LICENSE)
 
 An Obsidian plugin to paste data from Microsoft Excel, Google Sheets, Apple Numbers and LibreOffice Calc as Markdown tables in Obsidian editor.

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,8 +2,14 @@ import { Editor, MarkdownView, Plugin } from 'obsidian';
 import { excelToMarkdown, getExcelRows, isExcelData, excelRowsToMarkdown } from './excel-markdown-tables';
 
 export default class ExcelToMarkdownTablePlugin extends Plugin {
-	pasteHandler = (evt: ClipboardEvent, editor: Editor) => {
+	pasteHandler = (evt: ClipboardEvent, editor: Editor, markdownview: MarkdownView) => {
 		if (evt.clipboardData === null) {
+			return;
+		}
+
+		// Check for `Shift + Mod + V` triggered event.
+		// Do not handle `Shift + Mod + V` events.
+		if (evt.clipboardData.types.length === 1 && evt.clipboardData.types[0] === 'text/plain') {	
 			return;
 		}
 


### PR DESCRIPTION
- ignore the editor-paste event if the type of the clipboard data is just text/plain
- resolves #8